### PR TITLE
add numbers control from keyboard

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1116,375 +1116,818 @@
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581834007197) (:text |comp-cycloid-demo) (:id |HUEjqNbRD)
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581834007197)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582129848436) (:text |touch-key) (:id |8nE-PetL1)
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913052340) (:text |cursor) (:id |egHQ-WVh)
+                  |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913058625) (:text |states) (:id |1wrsHUYv)
                 :id |Eu6HRtCKQ
-              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581834025664)
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913074111)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581834025664) (:text |container) (:id |rIRNawEqX)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581834025664)
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581834025664)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581834025664) (:text |{}) (:id |xSatYxoQA)
-                    :id |2wZWkSpqi
-                  |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582131975050)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582131975050) (:text |comp-reset) (:id |6careTw7E)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582131975050)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581834025664) (:text |container) (:id |rIRNawEqX)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581834025664)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582131975050) (:text |[]) (:id |cvByep7e-)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582212054013) (:text |-40) (:id |ibGAMQ66w)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582212056574) (:text |40) (:id |rslftTGGD)
-                        :id |nJkOSuDqL
-                    :id |qooutHECc
-                  |q $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734310306)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734325922) (:text |graphics) (:id |wz35IWs7leaf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734326285)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581834025664) (:text |{}) (:id |xSatYxoQA)
+                        :id |2wZWkSpqi
+                      |q $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734310306)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734326655) (:text |{}) (:id |99RAt9pn)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734326902)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734325922) (:text |graphics) (:id |wz35IWs7leaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734326285)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734328773) (:text |:position) (:id |k9d_eEsqY)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734329485)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734326655) (:text |{}) (:id |99RAt9pn)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734326902)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734329896) (:text |[]) (:id |e1WguZrEu)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734330955) (:text |400) (:id |uWDBbJdBL)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734331620) (:text |400) (:id |QqOprDUO)
-                                :id |iSJHv5iB
-                            :id |4CMeVmNoI
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734333063)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734334738) (:text |:ops) (:id |6tIcoc4fleaf)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734336923)
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734328773) (:text |:position) (:id |k9d_eEsqY)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734329485)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734329896) (:text |[]) (:id |e1WguZrEu)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734330955) (:text |400) (:id |uWDBbJdBL)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734331620) (:text |400) (:id |QqOprDUO)
+                                    :id |iSJHv5iB
+                                :id |4CMeVmNoI
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734333063)
                                 :data $ {}
-                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734627868)
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734334738) (:text |:ops) (:id |6tIcoc4fleaf)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734336923)
                                     :data $ {}
-                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734334968)
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734627868)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734626223) (:text |concat) (:id |ioExHo_uE)
-                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734626520)
+                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734334968)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734627030) (:text |[]) (:id |8rHHso1E1)
-                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734656140)
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734626223) (:text |concat) (:id |ioExHo_uE)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734626520)
                                                 :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734658872) (:text |g) (:id |YIWrDBuG)
-                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734663205) (:text |:line-style) (:id |JPZyfRM_V)
-                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734663485)
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734627030) (:text |[]) (:id |8rHHso1E1)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734656140)
                                                     :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734663821) (:text |{}) (:id |B3O0sHdHX)
-                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734664021)
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734658872) (:text |g) (:id |YIWrDBuG)
+                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734663205) (:text |:line-style) (:id |JPZyfRM_V)
+                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734663485)
                                                         :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734664773) (:text |:color) (:id |MrbCK-xpU)
-                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735305232)
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734663821) (:text |{}) (:id |B3O0sHdHX)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734664021)
                                                             :data $ {}
-                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734666582)
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734664773) (:text |:color) (:id |MrbCK-xpU)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735305232)
                                                                 :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734668678) (:text |hslx) (:id |K0UimTHAd)
-                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734669056) (:text |0) (:id |_XsKFXKm-)
-                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734669294) (:text |0) (:id |1UW4h0wT)
-                                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735304157) (:text |100) (:id |umAQCQnvf)
-                                                                :id |Xx3knTvY
-                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735308734) (:text |rand-int) (:id |qxcwnDPY)
-                                                            :id |5bdL6rke
-                                                        :id |ZNjPMIEcf
-                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734671901)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734674260) (:text |:width) (:id |39ez13qQqleaf)
-                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737291583) (:text |1) (:id |qGNRGdA_L)
-                                                        :id |39ez13qQq
-                                                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734675900)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734677435) (:text |:alpha) (:id |A_dI_VrZzleaf)
-                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735051959) (:text |0.8) (:id |Wp09FuJes)
-                                                        :id |A_dI_VrZz
-                                                    :id |F93-N11RL
-                                                :id |Q7aAGsTq
-                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734678802)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734686606) (:text |:move-to) (:id |i9Xy7p_Uvleaf)
-                                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734687739) (:text |g) (:id |TPXDWm1T)
-                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734689673)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734689355) (:text |first) (:id |3tcH3dNSR)
-                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734700395) (:text |trail) (:id |NMYUL0pOA)
-                                                    :id |6px_Diwwg
-                                                :id |i9Xy7p_Uv
-                                            :id |d6z88SeeN
-                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734703036)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734707740) (:text |->>) (:id |sz0P9R8WOleaf)
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734710822) (:text |trail) (:id |nhcIuP9H)
-                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734711989) (:text |rest) (:id |5vMoEpqc)
-                                              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734712407)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735247793) (:text |mapcat) (:id |GakA3Nnb)
-                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734713388)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734714053) (:text |fn) (:id |-WS9lw933)
-                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734714973)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734715215) (:text |p) (:id |9ci_ieID)
-                                                        :id |X2WDzRT1a
-                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735001618)
-                                                        :data $ {}
-                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734717236)
-                                                            :data $ {}
-                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734724470) (:text |g) (:id |CKkiJ0dIleaf)
-                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734720914) (:text |:line-to) (:id |LBCGnZyV)
-                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734722421) (:text |p) (:id |SzDR8UtU)
-                                                            :id |CKkiJ0dI
-                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735002525) (:text |[]) (:id |2PsmFQxR)
-                                                        :id |CKcGpoY4Z
-                                                    :id |tweikKtKm
-                                                :id |ESSF-uXpT
-                                            :id |sz0P9R8WO
-                                        :id |6oSs3j1ar
-                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734629606) (:text |vec) (:id |he_Yr6ms)
-                                    :id |c_zGuRsqD
-                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734337492) (:text |let) (:id |AvoZj6Tz)
-                                  |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734337686)
-                                    :data $ {}
-                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734337837)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734339713) (:text |r1) (:id |Weiy9kTL9)
-                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734783664)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737400586) (:text |rand-int) (:id |YjSIWou4)
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735740225) (:text |400) (:id |4JC4D4xN3)
-                                            :id |XQZTzJXb
-                                        :id |Y15rZxwFp
-                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734345834)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734347006) (:text |r2) (:id |RhfxHoSj0leaf)
-                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734777491)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737402482) (:text |rand-int) (:id |-Kj39dxd)
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735920098) (:text |400) (:id |guI3mViOt)
-                                            :id |vjsnbN0yE
-                                        :id |RhfxHoSj0
-                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734694172)
-                                        :data $ {}
-                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734353970)
-                                            :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734427080) (:text |->>) (:id |dzEEXjCPAleaf)
-                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734436277)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734436988) (:text |range) (:id |n5_jIRgN)
-                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737280859) (:text |8000) (:id |arT2vPz8E)
-                                                :id |dvW-YkNu
-                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734441603)
-                                                :data $ {}
-                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734453579) (:text |map) (:id |0GsVlwXtleaf)
-                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734454822)
-                                                    :data $ {}
-                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734455871) (:text |fn) (:id |2K-OIo3o)
-                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734456202)
-                                                        :data $ {}
-                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734456749) (:text |idx) (:id |ZO2BaRn-l)
-                                                        :id |uttzWmw1
-                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734486153)
-                                                        :data $ {}
-                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735703015)
-                                                            :data $ {}
-                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734457459)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734463435) (:text |add-path) (:id |O8b1RyRnDleaf)
-                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734498985)
+                                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734666582)
                                                                     :data $ {}
-                                                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734525205)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734463737)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734532904) (:text |js/Math.cos) (:id |rGsWoYyUx)
-                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734539956) (:text |t) (:id |cS2QJypD)
-                                                                            :id |RDgBh5Q-G
-                                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734526538) (:text |*) (:id |u3SdyKILR)
-                                                                          |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734528588) (:text |dr) (:id |UgdY3S_x)
-                                                                        :id |2hNWeJbV
-                                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734499562) (:text |[]) (:id |puTKWc_s)
-                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734525205)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734463737)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734473550) (:text |js/Math.sin) (:id |rGsWoYyUx)
-                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734538320) (:text |t) (:id |cS2QJypD)
-                                                                            :id |RDgBh5Q-G
-                                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734526538) (:text |*) (:id |u3SdyKILR)
-                                                                          |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734528588) (:text |dr) (:id |UgdY3S_x)
-                                                                        :id |ZgExPp_4
-                                                                    :id |A8tQJW3L
-                                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734597368)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734597916) (:text |[]) (:id |K7eEHdUDleaf)
-                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734599902)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734601223) (:text |*) (:id |CjktW9Ho)
-                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735679438) (:text |dr2) (:id |5CNIcgvD9)
-                                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734604487)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734610355) (:text |js/Math.cos) (:id |h6u1NBBj)
-                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734612305) (:text |t2) (:id |dv0-M-rdX)
-                                                                            :id |Et48jYeQT
-                                                                        :id |uA7cZhQ8S
-                                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734599902)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734601223) (:text |*) (:id |CjktW9Ho)
-                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735680413) (:text |dr2) (:id |5CNIcgvD9)
-                                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734604487)
-                                                                            :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734617774) (:text |js/Math.sin) (:id |h6u1NBBj)
-                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734612305) (:text |t2) (:id |dv0-M-rdX)
-                                                                            :id |Et48jYeQT
-                                                                        :id |NhSKoHeo
-                                                                    :id |K7eEHdUD
-                                                                :id |O8b1RyRnD
-                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735705893) (:text |add-path) (:id |-gihijON)
-                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735708535)
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734668678) (:text |hslx) (:id |K0UimTHAd)
+                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734669056) (:text |0) (:id |_XsKFXKm-)
+                                                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734669294) (:text |0) (:id |1UW4h0wT)
+                                                                      |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735304157) (:text |100) (:id |umAQCQnvf)
+                                                                    :id |Xx3knTvY
+                                                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735308734) (:text |rand-int) (:id |qxcwnDPY)
+                                                                :id |5bdL6rke
+                                                            :id |ZNjPMIEcf
+                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734671901)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734674260) (:text |:width) (:id |39ez13qQqleaf)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737291583) (:text |1) (:id |qGNRGdA_L)
+                                                            :id |39ez13qQq
+                                                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734675900)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734677435) (:text |:alpha) (:id |A_dI_VrZzleaf)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735051959) (:text |0.8) (:id |Wp09FuJes)
+                                                            :id |A_dI_VrZz
+                                                        :id |F93-N11RL
+                                                    :id |Q7aAGsTq
+                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734678802)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734686606) (:text |:move-to) (:id |i9Xy7p_Uvleaf)
+                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734687739) (:text |g) (:id |TPXDWm1T)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734689673)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734689355) (:text |first) (:id |3tcH3dNSR)
+                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734700395) (:text |trail) (:id |NMYUL0pOA)
+                                                        :id |6px_Diwwg
+                                                    :id |i9Xy7p_Uv
+                                                :id |d6z88SeeN
+                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734703036)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734707740) (:text |->>) (:id |sz0P9R8WOleaf)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734710822) (:text |trail) (:id |nhcIuP9H)
+                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734711989) (:text |rest) (:id |5vMoEpqc)
+                                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734712407)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735247793) (:text |mapcat) (:id |GakA3Nnb)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734713388)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734714053) (:text |fn) (:id |-WS9lw933)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734714973)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734715215) (:text |p) (:id |9ci_ieID)
+                                                            :id |X2WDzRT1a
+                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735001618)
+                                                            :data $ {}
+                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734717236)
                                                                 :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |[]) (:id |cub1aZjSE)
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734724470) (:text |g) (:id |CKkiJ0dIleaf)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734720914) (:text |:line-to) (:id |LBCGnZyV)
+                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734722421) (:text |p) (:id |SzDR8UtU)
+                                                                :id |CKkiJ0dI
+                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735002525) (:text |[]) (:id |2PsmFQxR)
+                                                            :id |CKcGpoY4Z
+                                                        :id |tweikKtKm
+                                                    :id |ESSF-uXpT
+                                                :id |sz0P9R8WO
+                                            :id |6oSs3j1ar
+                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734629606) (:text |vec) (:id |he_Yr6ms)
+                                        :id |c_zGuRsqD
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734337492) (:text |let) (:id |AvoZj6Tz)
+                                      |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734337686)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734337837)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734339713) (:text |r1) (:id |Weiy9kTL9)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913173192)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913173880) (:text |:r1) (:id |BSox3fP__)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913175761) (:text |state) (:id |xfYTkxPF)
+                                                :id |kEHxoxY_
+                                            :id |Y15rZxwFp
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734345834)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734347006) (:text |r2) (:id |RhfxHoSj0leaf)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913177458)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913179163) (:text |:r2) (:id |VL7NikEk1)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913177458) (:text |state) (:id |2GgU6g1rk)
+                                                :id |gnetaOZus
+                                            :id |RhfxHoSj0
+                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734694172)
+                                            :data $ {}
+                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734353970)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734427080) (:text |->>) (:id |dzEEXjCPAleaf)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734436277)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734436988) (:text |range) (:id |n5_jIRgN)
+                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737280859) (:text |8000) (:id |arT2vPz8E)
+                                                    :id |dvW-YkNu
+                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734441603)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734453579) (:text |map) (:id |0GsVlwXtleaf)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734454822)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734455871) (:text |fn) (:id |2K-OIo3o)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734456202)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734456749) (:text |idx) (:id |ZO2BaRn-l)
+                                                            :id |uttzWmw1
+                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734486153)
+                                                            :data $ {}
+                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735703015)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734457459)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734463435) (:text |add-path) (:id |O8b1RyRnDleaf)
+                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734498985)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734525205)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734463737)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734532904) (:text |js/Math.cos) (:id |rGsWoYyUx)
+                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734539956) (:text |t) (:id |cS2QJypD)
+                                                                                :id |RDgBh5Q-G
+                                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734526538) (:text |*) (:id |u3SdyKILR)
+                                                                              |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734528588) (:text |dr) (:id |UgdY3S_x)
+                                                                            :id |2hNWeJbV
+                                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734499562) (:text |[]) (:id |puTKWc_s)
+                                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734525205)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734463737)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734473550) (:text |js/Math.sin) (:id |rGsWoYyUx)
+                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734538320) (:text |t) (:id |cS2QJypD)
+                                                                                :id |RDgBh5Q-G
+                                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734526538) (:text |*) (:id |u3SdyKILR)
+                                                                              |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734528588) (:text |dr) (:id |UgdY3S_x)
+                                                                            :id |ZgExPp_4
+                                                                        :id |A8tQJW3L
+                                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734597368)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734597916) (:text |[]) (:id |K7eEHdUDleaf)
+                                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734599902)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734601223) (:text |*) (:id |CjktW9Ho)
+                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735679438) (:text |dr2) (:id |5CNIcgvD9)
+                                                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734604487)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734610355) (:text |js/Math.cos) (:id |h6u1NBBj)
+                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734612305) (:text |t2) (:id |dv0-M-rdX)
+                                                                                :id |Et48jYeQT
+                                                                            :id |uA7cZhQ8S
+                                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734599902)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734601223) (:text |*) (:id |CjktW9Ho)
+                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735680413) (:text |dr2) (:id |5CNIcgvD9)
+                                                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734604487)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734617774) (:text |js/Math.sin) (:id |h6u1NBBj)
+                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734612305) (:text |t2) (:id |dv0-M-rdX)
+                                                                                :id |Et48jYeQT
+                                                                            :id |NhSKoHeo
+                                                                        :id |K7eEHdUD
+                                                                    :id |O8b1RyRnD
+                                                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735705893) (:text |add-path) (:id |-gihijON)
                                                                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735708535)
                                                                     :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |*) (:id |_pcDuvBnG)
-                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736824832) (:text |r3) (:id |7MxSZ3Rlw)
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |[]) (:id |cub1aZjSE)
+                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735708535)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |*) (:id |_pcDuvBnG)
+                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736824832) (:text |r3) (:id |7MxSZ3Rlw)
+                                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735708535)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |js/Math.cos) (:id |dBqLtFAoY)
+                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |t3) (:id |UwFXhKTV6)
+                                                                            :id |zyPMdrAJ0
+                                                                        :id |CNmhkm1pj
                                                                       |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735708535)
                                                                         :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |js/Math.cos) (:id |dBqLtFAoY)
-                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |t3) (:id |UwFXhKTV6)
-                                                                        :id |zyPMdrAJ0
-                                                                    :id |CNmhkm1pj
-                                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735708535)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |*) (:id |UcBNulwC2)
-                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736826156) (:text |r3) (:id |6DdT9K1dC)
-                                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735708535)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |js/Math.sin) (:id |pra0L1ipx)
-                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |t3) (:id |Mc6xRxh-O)
-                                                                        :id |LMvb6tDhP
-                                                                    :id |qU32czUqN
-                                                                :id |Pmw37mIuV
-                                                            :id |_r45CiNCl
-                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734486766) (:text |let) (:id |k-9dKc97U)
-                                                          |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734486973)
-                                                            :data $ {}
-                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734487118)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734541762) (:text |t) (:id |hFMdfig7P)
-                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734491123)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734492222) (:text |*) (:id |0ZhGu_fPq)
-                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734492827) (:text |idx) (:id |HFuJunLTR)
-                                                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737562630) (:text |0.11) (:id |EXP5TSek)
-                                                                    :id |4A9ttVO1
-                                                                :id |dI29LZAi
-                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734506654)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734507588) (:text |dr) (:id |34eCCzKV6leaf)
-                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734508802)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734511078) (:text |-) (:id |C9MG9dcv)
-                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734512643) (:text |r1) (:id |l77cVQN0o)
-                                                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734513104) (:text |r2) (:id |T3ze__UXg)
-                                                                    :id |RQayitTob
-                                                                :id |34eCCzKV6
-                                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734547486)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734549238) (:text |t2) (:id |KLgoPHpFHleaf)
-                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734824045)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734584020)
-                                                                        :data $ {}
-                                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734566955)
+                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |*) (:id |UcBNulwC2)
+                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736826156) (:text |r3) (:id |6DdT9K1dC)
+                                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735708535)
                                                                             :data $ {}
-                                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734582920)
-                                                                                :data $ {}
-                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734560288) (:text |*) (:id |NHfkn3V5N)
-                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734564998) (:text |t) (:id |LT5oyV8XT)
-                                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736626205) (:text |r1) (:id |DxPNzgCt)
-                                                                                :id |bnT96mfDo
-                                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734567593) (:text |/) (:id |WQ4dbI5R)
-                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737009397) (:text |r2) (:id |B6IJjcvn)
-                                                                            :id |ysLNC7mc_
-                                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734588239) (:text |unchecked-negate) (:id |S3zHHxQ5)
-                                                                        :id |1DJga9yxK
-                                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734829339) (:text |+) (:id |hz4XrJZW)
-                                                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735588532) (:text |tt1) (:id |qu3vDeOqZ)
-                                                                    :id |l9VveMP7L
-                                                                :id |KLgoPHpFH
-                                                              |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735608760)
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |js/Math.sin) (:id |pra0L1ipx)
+                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735708535) (:text |t3) (:id |Mc6xRxh-O)
+                                                                            :id |LMvb6tDhP
+                                                                        :id |qU32czUqN
+                                                                    :id |Pmw37mIuV
+                                                                :id |_r45CiNCl
+                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734486766) (:text |let) (:id |k-9dKc97U)
+                                                              |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734486973)
                                                                 :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735611735) (:text |dr2) (:id |pTp87KdEmleaf)
-                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735612405)
+                                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734487118)
                                                                     :data $ {}
-                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735612619) (:text |-) (:id |IatfEI6U)
-                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735613511) (:text |r2) (:id |8dU8hMHs5)
-                                                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735615628) (:text |r3) (:id |KxMd6gc0t)
-                                                                    :id |Gb2HB642K
-                                                                :id |pTp87KdEm
-                                                              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734547486)
-                                                                :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735626482) (:text |t3) (:id |KLgoPHpFHleaf)
-                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734824045)
-                                                                    :data $ {}
-                                                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734584020)
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734541762) (:text |t) (:id |hFMdfig7P)
+                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734491123)
                                                                         :data $ {}
-                                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734566955)
+                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734492222) (:text |*) (:id |0ZhGu_fPq)
+                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734492827) (:text |idx) (:id |HFuJunLTR)
+                                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737562630) (:text |0.11) (:id |EXP5TSek)
+                                                                        :id |4A9ttVO1
+                                                                    :id |dI29LZAi
+                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734506654)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734507588) (:text |dr) (:id |34eCCzKV6leaf)
+                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734508802)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734511078) (:text |-) (:id |C9MG9dcv)
+                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734512643) (:text |r1) (:id |l77cVQN0o)
+                                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734513104) (:text |r2) (:id |T3ze__UXg)
+                                                                        :id |RQayitTob
+                                                                    :id |34eCCzKV6
+                                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734547486)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734549238) (:text |t2) (:id |KLgoPHpFHleaf)
+                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734824045)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734584020)
                                                                             :data $ {}
-                                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734582920)
+                                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734566955)
                                                                                 :data $ {}
-                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734560288) (:text |*) (:id |NHfkn3V5N)
-                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735665495) (:text |t2) (:id |LT5oyV8XT)
-                                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736471390) (:text |r2) (:id |DxPNzgCt)
-                                                                                :id |bnT96mfDo
-                                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734567593) (:text |/) (:id |WQ4dbI5R)
-                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736997511) (:text |r3) (:id |B6IJjcvn)
-                                                                            :id |ysLNC7mc_
-                                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734588239) (:text |unchecked-negate) (:id |S3zHHxQ5)
-                                                                        :id |1DJga9yxK
-                                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734829339) (:text |+) (:id |hz4XrJZW)
-                                                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735650749) (:text |tt2) (:id |qu3vDeOqZ)
-                                                                    :id |l9VveMP7L
-                                                                :id |jrzm68NY
-                                                            :id |WGP-aLPVx
-                                                        :id |Cys8stw6
-                                                    :id |nzrKpAKqa
-                                                :id |0GsVlwXt
-                                            :id |dzEEXjCPA
-                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734698193) (:text |trail) (:id |o3qLC9_fn)
-                                        :id |y_m22ozRR
-                                      |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734904489)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735586175) (:text |tt1) (:id |deImkZZlleaf)
-                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734909835)
+                                                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734582920)
+                                                                                    :data $ {}
+                                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734560288) (:text |*) (:id |NHfkn3V5N)
+                                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734564998) (:text |t) (:id |LT5oyV8XT)
+                                                                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736626205) (:text |r1) (:id |DxPNzgCt)
+                                                                                    :id |bnT96mfDo
+                                                                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734567593) (:text |/) (:id |WQ4dbI5R)
+                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737009397) (:text |r2) (:id |B6IJjcvn)
+                                                                                :id |ysLNC7mc_
+                                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734588239) (:text |unchecked-negate) (:id |S3zHHxQ5)
+                                                                            :id |1DJga9yxK
+                                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734829339) (:text |+) (:id |hz4XrJZW)
+                                                                          |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735588532) (:text |tt1) (:id |qu3vDeOqZ)
+                                                                        :id |l9VveMP7L
+                                                                    :id |KLgoPHpFH
+                                                                  |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735608760)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735611735) (:text |dr2) (:id |pTp87KdEmleaf)
+                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582735612405)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735612619) (:text |-) (:id |IatfEI6U)
+                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735613511) (:text |r2) (:id |8dU8hMHs5)
+                                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735615628) (:text |r3) (:id |KxMd6gc0t)
+                                                                        :id |Gb2HB642K
+                                                                    :id |pTp87KdEm
+                                                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734547486)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735626482) (:text |t3) (:id |KLgoPHpFHleaf)
+                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734824045)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734584020)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734566955)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734582920)
+                                                                                    :data $ {}
+                                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734560288) (:text |*) (:id |NHfkn3V5N)
+                                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735665495) (:text |t2) (:id |LT5oyV8XT)
+                                                                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736471390) (:text |r2) (:id |DxPNzgCt)
+                                                                                    :id |bnT96mfDo
+                                                                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734567593) (:text |/) (:id |WQ4dbI5R)
+                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582736997511) (:text |r3) (:id |B6IJjcvn)
+                                                                                :id |ysLNC7mc_
+                                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734588239) (:text |unchecked-negate) (:id |S3zHHxQ5)
+                                                                            :id |1DJga9yxK
+                                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734829339) (:text |+) (:id |hz4XrJZW)
+                                                                          |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735650749) (:text |tt2) (:id |qu3vDeOqZ)
+                                                                        :id |l9VveMP7L
+                                                                    :id |jrzm68NY
+                                                                :id |WGP-aLPVx
+                                                            :id |Cys8stw6
+                                                        :id |nzrKpAKqa
+                                                    :id |0GsVlwXt
+                                                :id |dzEEXjCPA
+                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734698193) (:text |trail) (:id |o3qLC9_fn)
+                                            :id |y_m22ozRR
+                                          |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734904489)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734910426) (:text |rand) (:id |J6kEBWGp)
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735267351) (:text |6) (:id |sjhk-9wIE)
-                                            :id |Wh1hwWN5_
-                                        :id |deImkZZl
-                                      |l $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734345834)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735582618) (:text |r3) (:id |RhfxHoSj0leaf)
-                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734777491)
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735586175) (:text |tt1) (:id |deImkZZlleaf)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913183259)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913184745) (:text |:tt1) (:id |DiMS6LCcC)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913183259) (:text |state) (:id |rJ_g9BU4D)
+                                                :id |BPP7gXbsi
+                                            :id |deImkZZl
+                                          |l $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734345834)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582737403720) (:text |rand-int) (:id |-Kj39dxd)
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735803259) (:text |400) (:id |guI3mViOt)
-                                            :id |vjsnbN0yE
-                                        :id |bMRlhDnt
-                                      |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734904489)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735592600) (:text |tt2) (:id |deImkZZlleaf)
-                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734909835)
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735582618) (:text |r3) (:id |RhfxHoSj0leaf)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913180214)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913182445) (:text |:r3) (:id |WHWcV4Fv3)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913180214) (:text |state) (:id |OaETQi8U6)
+                                                :id |0Ke4W7HmM
+                                            :id |bMRlhDnt
+                                          |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582734904489)
                                             :data $ {}
-                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582734910426) (:text |rand) (:id |J6kEBWGp)
-                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735267351) (:text |6) (:id |sjhk-9wIE)
-                                            :id |Wh1hwWN5_
-                                        :id |8CsNj8lj
-                                    :id |NCwJUxCIz
-                                :id |qXZgqet0d
-                            :id |6tIcoc4f
-                        :id |0feGzTbFW
-                    :id |wz35IWs7
-                :id |KeL4UW-lr
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582735592600) (:text |tt2) (:id |deImkZZlleaf)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913185827)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913187750) (:text |:tt2) (:id |DJ6dKa4ZX)
+                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913185827) (:text |state) (:id |7mveKKhZA)
+                                                :id |Pb0XIsRJ7
+                                            :id |8CsNj8lj
+                                        :id |NCwJUxCIz
+                                    :id |qXZgqet0d
+                                :id |6tIcoc4f
+                            :id |0feGzTbFW
+                        :id |wz35IWs7
+                      |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913260779)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913265547) (:text |comp-numbers-control) (:id |zNrP6j5zleaf)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913268553) (:text |cursor) (:id |VgMAgODR)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913271171) (:text |state) (:id |5hSTAwyl)
+                        :id |zNrP6j5z
+                    :id |KeL4UW-lr
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913074835) (:text |let) (:id |7nMAp73h4)
+                  |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913075058)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913075211)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913075872) (:text |state) (:id |NceL6npvI)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913076207)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913076727) (:text |or) (:id |jmM1Sj4EB)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913077132)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913077979) (:text |:data) (:id |musqZeDXS)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913078882) (:text |states) (:id |0o5OA5mV)
+                                :id |W0Nc-18W
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913086108)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913087714) (:text |{}) (:id |WB853j54Z)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913088059)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913164444) (:text |:r1) (:id |7rP3dDCJq)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913108528) (:text |300) (:id |DpbTK4qmA)
+                                    :id |a4pATkfB6
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913097894)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913165916) (:text |:r2) (:id |xIVQ0ftkAleaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913112510) (:text |100) (:id |NTC7iq-N)
+                                    :id |xIVQ0ftkA
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913114635)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913167646) (:text |:r3) (:id |Rhsefw33leaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913117936) (:text |50) (:id |R7eMWSH1y)
+                                    :id |Rhsefw33
+                                  |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913118642)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913169043) (:text |:tt1) (:id |LPOSmQlDvleaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913146844) (:text |0) (:id |PFPgGw-sc)
+                                    :id |LPOSmQlDv
+                                  |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913118642)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913170458) (:text |:tt2) (:id |LPOSmQlDvleaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913145079) (:text |0) (:id |PFPgGw-sc)
+                                    :id |eR7Lh5Sl
+                                  |yT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913340813)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913343836) (:text |:selected) (:id |mdgGoaeUIleaf)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913346089) (:text |:r1) (:id |aWsyzQVG8)
+                                    :id |mdgGoaeUI
+                                :id |u2kIZVrU
+                            :id |V4oQzhvj
+                        :id |tankeE40
+                    :id |DkKPe6O_N
+                :id |KjhzjSVH
             :id |L6nsmhxp5
+          |comp-numbers-control $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913273038)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913278844) (:text |defcomp) (:id |QUXUlyVhG)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913273038) (:text |comp-numbers-control) (:id |6ruPu-hQy)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913273038)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913281072) (:text |cursor) (:id |ipxibkiUe)
+                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913281812) (:text |state) (:id |w2Q9Ej1qo)
+                :id |s3se8emsU
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913353793)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913288568)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913393530)
+                        :data $ {}
+                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913400584)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913457543)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913411342)
+                                    :data $ {}
+                                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913386380)
+                                        :data $ {}
+                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913303004)
+                                            :data $ {}
+                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913304095) (:text |rect) (:id |d2PEHpx1)
+                                              |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913304914)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913305273) (:text |{}) (:id |6BDB8kTkJ)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913513267)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913514579) (:text |:position) (:id |0UIesalm)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913514878)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913515112) (:text |[]) (:id |UIHLQxdq3)
+                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913516162) (:text |0) (:id |eZIfc78j5)
+                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913516477) (:text |0) (:id |u_HvYNs9q)
+                                                        :id |X3T_Ehmhj
+                                                    :id |pHpQLxjkY
+                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913518142)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913519245) (:text |:size) (:id |bNRdp0ROleaf)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913519567)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913519752) (:text |[]) (:id |RiUqfCkzT)
+                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913546095) (:text |80) (:id |kq2buPV-)
+                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913573204) (:text |30) (:id |YF50jqQJ)
+                                                        :id |juvP6joUU
+                                                    :id |bNRdp0RO
+                                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913532138)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913533038) (:text |:fill) (:id |MRkhV6-Tleaf)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913623114)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913534031)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913536610) (:text |hslx) (:id |wG52kcIy)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913537195) (:text |0) (:id |10X4hKHA8)
+                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913537670) (:text |0) (:id |BJlc8LKFW)
+                                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913636614) (:text |40) (:id |SD4HjVDR4)
+                                                            :id |wUKL6DHwS
+                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913623878) (:text |if) (:id |kfuaEYI-g)
+                                                          |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913627813)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913627046) (:text |selected) (:id |C4nZLukr)
+                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913628410) (:text |=) (:id |lMaEE-vB)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913629894) (:text |param) (:id |wh75r9iXh)
+                                                            :id |bCcbHPkx
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913534031)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913536610) (:text |hslx) (:id |wG52kcIy)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913537195) (:text |0) (:id |10X4hKHA8)
+                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913537670) (:text |0) (:id |BJlc8LKFW)
+                                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913635013) (:text |20) (:id |SD4HjVDR4)
+                                                            :id |UImamE0_z
+                                                        :id |x_rHl5CX
+                                                    :id |MRkhV6-T
+                                                  |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913644883)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913647178) (:text |:on) (:id |5zQL8IDCnleaf)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913647643)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913648615) (:text |{}) (:id |_9haFriQV)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913648887)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913649597) (:text |:click) (:id |U-hO1l3X0)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913649861)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913650749) (:text |fn) (:id |cqxIH1zYd)
+                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913650996)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913651198) (:text |e) (:id |Tyj2wPxQI)
+                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913652810) (:text |d!) (:id |PoAfN4k5Q)
+                                                                    :id |3zbkbiww1
+                                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913653383)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913654713) (:text |d!) (:id |60UUc5QZtleaf)
+                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913656355) (:text |:states) (:id |4hN7Xm-E)
+                                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913656794)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913657021) (:text |[]) (:id |VYYvgq85X)
+                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913659158) (:text |cursor) (:id |NYr4JVkI)
+                                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913667412)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913670033) (:text |assoc) (:id |JzZgUu8I)
+                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913670756) (:text |state) (:id |GKxbsE8K)
+                                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913673183) (:text |:selected) (:id |XIuS0IYxB)
+                                                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913674789) (:text |param) (:id |_jj_gSzhQ)
+                                                                            :id |f7s_MRgC
+                                                                        :id |ZUMR4p2ji
+                                                                    :id |60UUc5QZt
+                                                                :id |T8pEDMTB5
+                                                            :id |QHXqTp_QU
+                                                        :id |xI1C6kRqN
+                                                    :id |5zQL8IDCn
+                                                  |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913964239)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913970718) (:text |:on-keyboard) (:id |WkiZPQ7Dleaf)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913998780)
+                                                        :data $ {}
+                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913974659)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913976993) (:text |{}) (:id |QmUUsOUe)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913977248)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913978795) (:text |:down) (:id |mlJkIEtP)
+                                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913979397)
+                                                                    :data $ {}
+                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913980024) (:text |fn) (:id |hWSJBGNLH)
+                                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913980312)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913980546) (:text |e) (:id |sEpfbvDb)
+                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913981203) (:text |d!) (:id |UYta286NE)
+                                                                        :id |7m998zVNy
+                                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914026334)
+                                                                        :data $ {}
+                                                                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913982364)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914025198) (:text |:key) (:id |zF8aHr1gleaf)
+                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913985414) (:text |e) (:id |GlZQKro00)
+                                                                            :id |zF8aHr1g
+                                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914028375) (:text |case) (:id |lXr2fi_2d)
+                                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914029584)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914032678) (:text "|\"ArrowUp") (:id |Di7v3Dslleaf)
+                                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914069073)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914069073) (:text |d!) (:id |qJNKngX5j)
+                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914069073) (:text |:states) (:id |UUxK8pAz0)
+                                                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914069073)
+                                                                                    :data $ {}
+                                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914069073) (:text |[]) (:id |g8SwWjlE9)
+                                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914069073) (:text |cursor) (:id |v9NVVZVzG)
+                                                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914069073)
+                                                                                        :data $ {}
+                                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914069073) (:text |assoc) (:id |5gmbdBtG3)
+                                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914069073) (:text |state) (:id |c0nQCIVIF)
+                                                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914075766) (:text |selected) (:id |XiGGydmJY)
+                                                                                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914098881)
+                                                                                            :data $ {}
+                                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914099227) (:text |+) (:id |NhobJVspm)
+                                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914333713) (:text |1) (:id |rX2eUDriR)
+                                                                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914104463)
+                                                                                                :data $ {}
+                                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914105121) (:text |get) (:id |OOSmvR04)
+                                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914105774) (:text |state) (:id |eWximZwoI)
+                                                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914106987) (:text |selected) (:id |vuy9crUYA)
+                                                                                                :id |SpZBoYYIO
+                                                                                            :id |81dv4Wgi_
+                                                                                        :id |sv3-bdBia
+                                                                                    :id |M-JcT_WxW
+                                                                                :id |M2yILbV46
+                                                                            :id |Di7v3Dsl
+                                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914029584)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914059404) (:text "|\"ArrowDown") (:id |Di7v3Dslleaf)
+                                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914109332)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |d!) (:id |3ADt4CoUf)
+                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |:states) (:id |pFJKoZNkr)
+                                                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914109332)
+                                                                                    :data $ {}
+                                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |[]) (:id |4dPHZfbVA)
+                                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |cursor) (:id |mPtI-WL3Q)
+                                                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914109332)
+                                                                                        :data $ {}
+                                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |assoc) (:id |s-ZVNBhqq)
+                                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |state) (:id |ORgbAKpeL)
+                                                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |selected) (:id |rBGAqxoM8)
+                                                                                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914109332)
+                                                                                            :data $ {}
+                                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914111687) (:text |-) (:id |MhhaZETcO)
+                                                                                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914109332)
+                                                                                                :data $ {}
+                                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |get) (:id |vD864hU34f)
+                                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |state) (:id |LtvOQDa32N)
+                                                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |selected) (:id |EFMNyaNuk3)
+                                                                                                :id |-JforW1fW
+                                                                                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914334776) (:text |1) (:id |AHaXDxbW)
+                                                                                            :id |Lx5h9JDgb
+                                                                                        :id |HWLjuKnVP
+                                                                                    :id |kFyIo_gc9
+                                                                                :id |vcgfZAk86
+                                                                            :id |AefxbJtk
+                                                                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914037675)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914052683) (:text |js/console.warn) (:id |xLFoatQileaf)
+                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914055452) (:text "|\"not handled") (:id |JgbH3UP5)
+                                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914055937) (:text |e) (:id |VbT0ch_AL)
+                                                                            :id |xLFoatQi
+                                                                          |t $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914029584)
+                                                                            :data $ {}
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914360480) (:text "|\"`") (:id |Di7v3Dslleaf)
+                                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914109332)
+                                                                                :data $ {}
+                                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |d!) (:id |3ADt4CoUf)
+                                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |:states) (:id |pFJKoZNkr)
+                                                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914109332)
+                                                                                    :data $ {}
+                                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |[]) (:id |4dPHZfbVA)
+                                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |cursor) (:id |mPtI-WL3Q)
+                                                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914109332)
+                                                                                        :data $ {}
+                                                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |assoc) (:id |s-ZVNBhqq)
+                                                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |state) (:id |ORgbAKpeL)
+                                                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914109332) (:text |selected) (:id |rBGAqxoM8)
+                                                                                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914307913)
+                                                                                            :data $ {}
+                                                                                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914280721)
+                                                                                                :data $ {}
+                                                                                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914246117)
+                                                                                                    :data $ {}
+                                                                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914265332) (:text |js/prompt) (:id |b4IU2xvm)
+                                                                                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914278027) (:text "|\"specify a number") (:id |-sAlbhwX)
+                                                                                                    :id |5CFYdQui
+                                                                                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914391027) (:text |js/parseFloat) (:id |jFgyIXjTh)
+                                                                                                :id |XyNGWVvL
+                                                                                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914308600) (:text |or) (:id |m3pDOf8x)
+                                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914309383) (:text |0) (:id |iXbJ-BTu)
+                                                                                            :id |1a5NcUiLA
+                                                                                        :id |HWLjuKnVP
+                                                                                    :id |kFyIo_gc9
+                                                                                :id |vcgfZAk86
+                                                                            :id |WiycoP_v
+                                                                        :id |VFV_-pDpR
+                                                                    :id |EcwKOWKs
+                                                                :id |l5RBH3lbN
+                                                            :id |MDEX7AMFB
+                                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913999440) (:text |if) (:id |YohPPFKl)
+                                                          |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582914003238)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914002888) (:text |=) (:id |iBVKsIR9f)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914004483) (:text |param) (:id |NdrxdvTsT)
+                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914007061) (:text |selected) (:id |LoETpExwk)
+                                                            :id |N7Q9ASmH
+                                                        :id |_SqK4gmS
+                                                    :id |WkiZPQ7D
+                                                :id |ZENC9N1DF
+                                            :id |FWxeOoL2
+                                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913387432) (:text |container) (:id |QABtWqpoe)
+                                          |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913388047)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913388400) (:text |{}) (:id |vWZ7yFXvn)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913419033)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913421312) (:text |:position) (:id |A-cxa6hF7)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913421750)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913422046) (:text |[]) (:id |Kemio_pcM)
+                                                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913424150)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913424795) (:text |*) (:id |56RuS8KT4)
+                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913426480) (:text |idx) (:id |Gb93RrrUk)
+                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913427162) (:text |100) (:id |xcKJeUHZ5)
+                                                        :id |K93hc65r
+                                                      |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582914480357) (:text |-80) (:id |uKjCVALe7)
+                                                    :id |hMMCk8vQ1
+                                                :id |3MgSr1Izz
+                                            :id |1LieDeNiH
+                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                            :data $ {}
+                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |text) (:id |n43QCqb5y)
+                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                :data $ {}
+                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |{}) (:id |bLoVKHgO7)
+                                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |:text) (:id |fDQHIgrij)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |str) (:id |uP0tleNCx)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |name) (:id |MdiDQWjP-)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |param) (:id |nYNRIAAGy)
+                                                            :id |BBce7ylCp
+                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text "|\": ") (:id |Fu6hOdRo9)
+                                                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |get) (:id |WyrNd7mux)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |state) (:id |tdUz5UpUV)
+                                                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |param) (:id |x5PDmRWqeE)
+                                                            :id |hoXD5dbMM
+                                                        :id |QIZT5CznS
+                                                    :id |DkXDy-Iei
+                                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |:position) (:id |pqYN2qgdup)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |[]) (:id |4uFMtq70EF)
+                                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |4) (:id |sDlguE81yK)
+                                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |8) (:id |XUodtNDl6r)
+                                                        :id |hp-9O60IdQ
+                                                    :id |5wBu6EkRFW
+                                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                    :data $ {}
+                                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |:style) (:id |NoMOPsMGwj)
+                                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                        :data $ {}
+                                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |{}) (:id |6-vEBjC2T9)
+                                                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |:fill) (:id |zvPVEaE6v_)
+                                                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                                :data $ {}
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |hslx) (:id |qgoB04L51g)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |0) (:id |fZdcreFzZY)
+                                                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |0) (:id |B8WL7ogA-S)
+                                                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |100) (:id |1PQK8kTthJ)
+                                                                :id |BK2QD6p9zQ
+                                                            :id |A6gWkskO6g
+                                                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913621104)
+                                                            :data $ {}
+                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |:font-size) (:id |jsfdvNg39X)
+                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913621104) (:text |13) (:id |mBnw5jPFaM)
+                                                            :id |SacsEtLbJJ
+                                                        :id |q5Yg8BFWRo
+                                                    :id |6Yp0Y9V1Hp
+                                                :id |64Wsud3sR
+                                            :id |h4aF9N7lQ
+                                        :id |78L-2ggDe
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913411863) (:text |[]) (:id |edYPpWHXJ)
+                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913413319) (:text |idx) (:id |S_rUIlio)
+                                    :id |xq3guARYn
+                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913458748) (:text |fn) (:id |ihg97egE)
+                                  |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913462369)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913462369) (:text |idx) (:id |Pi1msea3R)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913462369) (:text |param) (:id |sX4ZBvY9x)
+                                    :id |4Wm5if8dP
+                                :id |zrhPF9vwn
+                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913454680) (:text |map-indexed) (:id |YHordwd1P)
+                            :id |JpQBqVojJ
+                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913395044) (:text |->>) (:id |42j67JbRk)
+                          |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913398745) (:text |params) (:id |YS0umt6R)
+                        :id |o2OPABhIe
+                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913382278) (:text |create-list) (:id |xzodMGZGU)
+                      |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913290061)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913290366) (:text |{}) (:id |oojqegRyf)
+                        :id |Ut34DRC6m
+                      |H $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913383977) (:text |:container) (:id |_pyLyyI1y)
+                    :id |g42qnxnPE
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913354397) (:text |let) (:id |98ng0uwD)
+                  |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913354583)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913354760)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913357280) (:text |selected) (:id |oAXudypA_)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913357509)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913358679) (:text |:selected) (:id |yiBaXOlaH)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913359338) (:text |state) (:id |wQySfWURZ)
+                            :id |yKpUgA8_w
+                        :id |G7hulXMU4
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913363309)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913365682) (:text |params) (:id |XSVetxcA_leaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913366193)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913367070) (:text |[]) (:id |bwdIKrkFZ)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913367999) (:text |:r1) (:id |QSPeIiEfP)
+                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913370194) (:text |:r2) (:id |UnyoJlUa)
+                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913371237) (:text |:r3) (:id |m2YYIFqMc)
+                              |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913372794) (:text |:tt1) (:id |2oZioC-W0)
+                              |y $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913450497) (:text |:tt2) (:id |DCkY5e2sq)
+                            :id |WPViEcnp
+                        :id |XSVetxcA_
+                    :id |wcHF53vHG
+                :id |4jLfwAjZX
+            :id |XMaxGk6YM
         :proc $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581833988437) (:data $ {}) (:id |vCvbeVZ1B)
       |app.page $ {}
         :ns $ {} (:type :expr) (:time 1499755354983) (:id |Hyvlej_Y5arb)
@@ -3491,6 +3934,14 @@
                     :data $ {}
                       |T $ {} (:type :leaf) (:author |rJG4IHzWf) (:time 1512359514709) (:text |:tab) (:id |BJ0oxjdFq6rb) (:at 1574442604907) (:by |rJG4IHzWf)
                       |j $ {} (:type :leaf) (:author |rJG4IHzWf) (:time 1512359516026) (:text |:home) (:id |BJy2go_tcaBZ) (:at 1581746410010) (:by |rJG4IHzWf)
+                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582912977009)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582912978059) (:text |:states) (:id |NoEOPRpHHleaf)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582912978572)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582912979894) (:text |{}) (:id |2MT3dhec)
+                        :id |cKbN2XyI_
+                    :id |NoEOPRpHH
         :proc $ {} (:type :expr) (:time 1499755354983) (:id |rkmjesdF9Trb) (:data $ {})
       |app.updater $ {}
         :ns $ {} (:type :expr) (:time 1499755354983) (:id |B1Z1gjdFqaBZ)
@@ -5425,6 +5876,57 @@
                         :id |MxspIjCks
                     :id |PZC31RZqu
                 :id |qttm-e0fC
+              |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913706374)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913709574) (:text |case) (:id |dbSmS6VFlleaf)
+                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913711639) (:text |op) (:id |QeogaKmYF)
+                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913712477)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913718979) (:text |:states) (:id |9vv0VXNi4)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913720576)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913766974) (:text |when-not) (:id |SZ38VoyY2)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913767744)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913769414) (:text |and) (:id |qr3arplu)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913769678)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913772516) (:text |vector?) (:id |-s7_UzwZJ)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913775205) (:text |op-data) (:id |Zkq_RzIV)
+                                :id |UcGIqugtu
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913776962)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913777670) (:text |=) (:id |97-sUH0Cleaf)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913778398) (:text |2) (:id |SoNwuHjl)
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913779049)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913779679) (:text |count) (:id |JOd72ugjP)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913780681) (:text |op-data) (:id |TL2Gg-SDU)
+                                    :id |nFGa6_wjx
+                                :id |97-sUH0C
+                              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913782943)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913785032) (:text |vector?) (:id |uP-WNSHXleaf)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913785410)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913786396) (:text |first) (:id |pDMZ_GjA)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913792779) (:text |op-data) (:id |eAfSMbQab)
+                                    :id |3sS_O8bDt
+                                :id |uP-WNSHX
+                            :id |rmvqK4Uiu
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913794646)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913807049) (:text |js/console.error) (:id |k6Ek2y6Uvleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913830746) (:text "|\"Invalid states op:") (:id |grgCoVYt)
+                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913834236) (:text |op-data) (:id |YbTPpEW1)
+                            :id |k6Ek2y6Uv
+                        :id |6OBNWfX65
+                    :id |p6CsbNIih
+                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913714413)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913714729) (:text |do) (:id |YSYP3sMwleaf)
+                    :id |YSYP3sMw
+                :id |dbSmS6VFl
           |main! $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1548266583359) (:id |N84ryjxHeb)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1548266583359) (:text |defn) (:id |VtP_sQu6yt)
@@ -5537,6 +6039,53 @@
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581757709446) (:text |:touch-key) (:id |15o1JSo2)
                           |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581757717815) (:text |op-id) (:id |LC1m2flt)
                         :id |JmNXLIUh
+                  |uT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913689028)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913690413) (:text |:states) (:id |ksPDF2c5leaf)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913692022)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913879232) (:text |let) (:id |xEs9Pnzc)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913879449)
+                            :data $ {}
+                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913879584)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913887719)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913886835) (:text |[]) (:id |U2cHznKwD)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913889901) (:text |cursor) (:id |hKIEtEo-)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913893298) (:text |new-state) (:id |-RQJQVI9)
+                                    :id |gyv3haXD
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913897565) (:text |op-data) (:id |kBYKbnPyk)
+                                :id |8JQFztD8K
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913898793)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913899601) (:text |path) (:id |2MGmA6jC1leaf)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913899897)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913900347) (:text |conj) (:id |qaU9RQu48)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913901759) (:text |cursor) (:id |tpZget1v_)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913904300) (:text |:data) (:id |35vOHyrLh)
+                                    :id |jx5yp83v0
+                                :id |2MGmA6jC1
+                            :id |kgQA2WMhW
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913905396)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913910175) (:text |assoc-in) (:id |yL1wj6YJwleaf)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913911033) (:text |store) (:id |LWrM4vmpS)
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913915496)
+                                :data $ {}
+                                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913911884)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913912229) (:text |[]) (:id |DrBi8Atl)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913913586) (:text |:states) (:id |oWNR5q4Yi)
+                                    :id |KXLUmUL8t
+                                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913916449) (:text |concat) (:id |xBTpKnf0A)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913924137) (:text |path) (:id |PjDk719m)
+                                :id |jQ4ZpUcu
+                              |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913929080) (:text |new-state) (:id |HZKL_MYH)
+                            :id |yL1wj6YJw
+                        :id |ZRNZGpAeB
+                    :id |ksPDF2c5
         :proc $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1548266580449) (:id |E53mYF93tU) (:data $ {})
       |app.comp.sun-demo $ {}
         :ns $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581776818038)
@@ -6719,7 +7268,17 @@
                                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581777122399)
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582733669757) (:text |comp-cycloid-demo) (:id |EGd_P7GzZ)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581834063566) (:text |touch-key) (:id |nDLOF7Sd)
+                                      |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913017578)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913017752) (:text |[]) (:id |g3RJyzvU)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913033906) (:text |:cycloid) (:id |DjgdxGR-I)
+                                        :id |pHNTBKjFP
+                                      |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913023183)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913023671) (:text |get) (:id |QTRYHst4)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913024408) (:text |states) (:id |MBurk6Io6)
+                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913029901) (:text |:cycloid) (:id |ez_Plpvd)
+                                        :id |uUqwprZu
                                     :id |69Nt4toz
                                 :id |36CeAeSU
                               |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581747671626)
@@ -6873,6 +7432,15 @@
                               |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581757772292) (:text |:touch-key) (:id |hWW4uU3i)
                             :id |ibiV9GCZ
                         :id |5LCFecJG4
+                      |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913038240)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913040090) (:text |states) (:id |b4BsXTn4leaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582913040591)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913041470) (:text |:states) (:id |6Gkd3gvkq)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582913042241) (:text |store) (:id |lezAmHSVu)
+                            :id |4y7aShdCr
+                        :id |b4BsXTn4
                     :id |__Y93RGwi
                 :id |A0_92kc8
           |comp-tab $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581747048172)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "http-server": "^0.12.1",
-    "shadow-cljs": "^2.8.87"
+    "shadow-cljs": "^2.8.89"
   },
   "dependencies": {
     "color": "^3.1.2",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -6,7 +6,7 @@
     [mvc-works/shell-page "0.1.10"]
     [cumulo/util "0.1.10"]
     [respo "0.11.5"]
-    [quamolit/phlox "0.1.5-a2"]
+    [quamolit/phlox "0.1.6-a1"]
     [org.clojure/core.incubator "0.1.4"]
     [org.clojure/core.rrb-vector "0.1.1"]
   ]

--- a/src/app/comp/cycloid_demo.cljs
+++ b/src/app/comp/cycloid_demo.cljs
@@ -7,33 +7,77 @@
             [app.util :refer [rand-point add-path subtract-path multiply-path]]))
 
 (defcomp
+ comp-numbers-control
+ (cursor state)
+ (let [selected (:selected state), params [:r1 :r2 :r3 :tt1 :tt2]]
+   (create-list
+    :container
+    {}
+    (->> params
+         (map-indexed
+          (fn [idx param]
+            [idx
+             (container
+              {:position [(* idx 100) -80]}
+              (rect
+               {:position [0 0],
+                :size [80 30],
+                :fill (if (= selected param) (hslx 0 0 40) (hslx 0 0 20)),
+                :on {:click (fn [e d!] (d! :states [cursor (assoc state :selected param)]))},
+                :on-keyboard (if (= param selected)
+                  {:down (fn [e d!]
+                     (case (:key e)
+                       "ArrowUp"
+                         (d!
+                          :states
+                          [cursor (assoc state selected (+ 1 (get state selected)))])
+                       "ArrowDown"
+                         (d!
+                          :states
+                          [cursor (assoc state selected (- (get state selected) 1))])
+                       "`"
+                         (d!
+                          :states
+                          [cursor
+                           (assoc
+                            state
+                            selected
+                            (or (js/parseFloat (js/prompt "specify a number")) 0))])
+                       (js/console.warn "not handled" e)))})})
+              (text
+               {:text (str (name param) ": " (get state param)),
+                :position [4 8],
+                :style {:fill (hslx 0 0 100), :font-size 13}}))]))))))
+
+(defcomp
  comp-cycloid-demo
- (touch-key)
- (container
-  {}
-  (graphics
-   {:position [400 400],
-    :ops (let [r1 (rand-int 400)
-               r2 (rand-int 400)
-               r3 (rand-int 400)
-               tt1 (rand 6)
-               tt2 (rand 6)
-               trail (->> (range 8000)
-                          (map
-                           (fn [idx]
-                             (let [t (* idx 0.11)
-                                   dr (- r1 r2)
-                                   dr2 (- r2 r3)
-                                   t2 (+ tt1 (unchecked-negate (/ (* t r1) r2)))
-                                   t3 (+ tt2 (unchecked-negate (/ (* t2 r2) r3)))]
-                               (add-path
-                                (add-path
-                                 [(* dr (js/Math.cos t)) (* dr (js/Math.sin t))]
-                                 [(* dr2 (js/Math.cos t2)) (* dr2 (js/Math.sin t2))])
-                                [(* r3 (js/Math.cos t3)) (* r3 (js/Math.sin t3))])))))]
-      (vec
-       (concat
-        [(g :line-style {:color (rand-int (hslx 0 0 100)), :width 1, :alpha 0.8})
-         (g :move-to (first trail))]
-        (->> trail rest (mapcat (fn [p] [(g :line-to p)]))))))})
-  (comp-reset [-40 40])))
+ (cursor states)
+ (let [state (or (:data states) {:r1 300, :r2 100, :r3 50, :tt1 0, :tt2 0, :selected :r1})]
+   (container
+    {}
+    (graphics
+     {:position [400 400],
+      :ops (let [r1 (:r1 state)
+                 r2 (:r2 state)
+                 r3 (:r3 state)
+                 tt1 (:tt1 state)
+                 tt2 (:tt2 state)
+                 trail (->> (range 8000)
+                            (map
+                             (fn [idx]
+                               (let [t (* idx 0.11)
+                                     dr (- r1 r2)
+                                     dr2 (- r2 r3)
+                                     t2 (+ tt1 (unchecked-negate (/ (* t r1) r2)))
+                                     t3 (+ tt2 (unchecked-negate (/ (* t2 r2) r3)))]
+                                 (add-path
+                                  (add-path
+                                   [(* dr (js/Math.cos t)) (* dr (js/Math.sin t))]
+                                   [(* dr2 (js/Math.cos t2)) (* dr2 (js/Math.sin t2))])
+                                  [(* r3 (js/Math.cos t3)) (* r3 (js/Math.sin t3))])))))]
+        (vec
+         (concat
+          [(g :line-style {:color (rand-int (hslx 0 0 100)), :width 1, :alpha 0.8})
+           (g :move-to (first trail))]
+          (->> trail rest (mapcat (fn [p] [(g :line-to p)]))))))})
+    (comp-numbers-control cursor state))))

--- a/src/app/container.cljs
+++ b/src/app/container.cljs
@@ -35,7 +35,7 @@
 (defcomp
  comp-container
  (store)
- (let [tab (:tab store), touch-key (:touch-key store)]
+ (let [tab (:tab store), states (:states store), touch-key (:touch-key store)]
    (container
     {}
     (container
@@ -66,6 +66,6 @@
        :rects (comp-rects-demo touch-key)
        :chars (comp-chars-demo touch-key)
        :bezier (comp-bezier-demo touch-key)
-       :cycloid (comp-cycloid-demo touch-key)
+       :cycloid (comp-cycloid-demo [:cycloid] (get states :cycloid))
        :chord (comp-chord-demo touch-key)
        (text {:text (str "Unknown " tab), :style {:fill (hslx 0 0 100)}, :position [0 0]}))))))

--- a/src/app/main.cljs
+++ b/src/app/main.cljs
@@ -12,10 +12,18 @@
   (case op
     :tab (assoc store :tab op-data)
     :touch (assoc store :touch-key op-id)
+    :states
+      (let [[cursor new-state] op-data, path (conj cursor :data)]
+        (assoc-in store (concat [:states] path) new-state))
     (do (println "unknown op" op op-data) store)))
 
 (defn dispatch! [op op-data]
   (println "dispatch!" op op-data)
+  (case op
+    :states
+      (when-not (and (vector? op-data) (= 2 (count op-data)) (vector? (first op-data)))
+        (js/console.error "Invalid states op:" op-data))
+    (do))
   (let [op-id (shortid/generate)] (reset! *store (updater @*store op op-data op-id))))
 
 (defn main! []

--- a/src/app/schema.cljs
+++ b/src/app/schema.cljs
@@ -1,4 +1,4 @@
 
 (ns app.schema )
 
-(def store {:tab :home})
+(def store {:tab :home, :states {}})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,10 +1094,10 @@ shadow-cljs-jar@1.3.2:
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz#97273afe1747b6a2311917c1c88d9e243c81957b"
   integrity sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==
 
-shadow-cljs@^2.8.87:
-  version "2.8.87"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.87.tgz#8f258ec2c580e74580166afa5f90770de59da525"
-  integrity sha512-89QfI5nL5/rQK9jhJYcjaHIF7LFQC9LQn9RaK1aPBh9S5DBoCN71rdO99PDt95Cf3cCR9qxLG5CpdCdigMFbkw==
+shadow-cljs@^2.8.89:
+  version "2.8.89"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.8.89.tgz#45b9380840708ef9c9f494786469cc6f4556d609"
+  integrity sha512-nDf9xiXiLjppou4zBTkZ5pGtcZv8MLdQFwwpmfVkFX6tgQ5m2/boUPi2oJHifZxZHX5KjOGetl6pSJ6TjV6qPA==
   dependencies:
     mkdirp "^0.5.1"
     node-libs-browser "^2.0.0"


### PR DESCRIPTION
Cycloid demo 增加了控制项, 上下键 +1 -1, `` ` `` 键插入数字, 点击切换参数. 可以逐个数据探索...

![image](https://user-images.githubusercontent.com/449224/75577295-abaf1e80-5a9c-11ea-9e14-66e8faa37210.png)
![image](https://user-images.githubusercontent.com/449224/75577428-eadd6f80-5a9c-11ea-9934-0eeddde44e81.png)
![image](https://user-images.githubusercontent.com/449224/75577455-f6c93180-5a9c-11ea-83a3-28b8dcc7388b.png)
![image](https://user-images.githubusercontent.com/449224/75577514-195b4a80-5a9d-11ea-8148-ea5f61dccb4c.png)
![image](https://user-images.githubusercontent.com/449224/75577536-24ae7600-5a9d-11ea-8588-474eb96ef307.png)
